### PR TITLE
commit: another test for packporting two branches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ Backporting
 ----------
 Back porting a PR just add a label to candidate PR _which is opened aginst master_, the label should be `backport open-release/{release-name}.master` i.e. for palm `backport open-release/palm.maser`.
 
+Let's try again backporting for two release branches
+
 Getting Help
 ------------
 


### PR DESCRIPTION
   In this test we would want to the github bot to open
   PRs for two release branches.
   By adding two labels that crosspond to each release
